### PR TITLE
chore: remove apiBearerAuth decorator from getAllPets

### DIFF
--- a/backend/src/modules/Auth/dto/registerUser.dto.ts
+++ b/backend/src/modules/Auth/dto/registerUser.dto.ts
@@ -1,22 +1,18 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsBoolean,
   IsDateString,
   IsEmail,
   IsEnum,
-  IsIn,
   IsNotEmpty,
-  IsOptional,
   IsString,
   Length,
   Matches,
 } from 'class-validator';
 import { Genders } from 'src/common/enums/genders.enum';
-import { Role } from 'src/common/enums/roles.enum';
 
 export class RegisterUserDto {
   @ApiProperty({ example: 'John', description: 'Nombre del usuario' })
-  @IsString()
+  @IsString({ message: 'El nombre debe ser una cadena de texto' })
   @IsNotEmpty({ message: 'El nombre es requerido' })
   name!: string;
 

--- a/backend/src/modules/Pets/pets.controller.ts
+++ b/backend/src/modules/Pets/pets.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Post, Put, Delete, Param, Body, UseGuards, Query, HttpCode } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Query,
+  HttpCode,
+} from '@nestjs/common';
 import { PetsService } from './pets.service';
 import { Pets } from './pets.entity';
 import { CreatePetDto } from './dto/create-pet.dto';
@@ -26,7 +37,6 @@ import { FindPetsDto } from './dto/find-pets.dto';
 import { PaginatedResponse } from './interfaces/pagination.interface';
 
 @ApiTags('Pets')
-@ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('pets')
 export class PetsController {
@@ -39,17 +49,17 @@ export class PetsController {
   @ApiOkResponse({
     description: 'Retorno exitoso de las mascotas',
     schema: {
-        properties: {
-            items: {
-                type: 'array',
-                items: { $ref: getSchemaPath(Pets) }
-            },
-            total: { type: 'number' },
-            page: { type: 'number' },
-            limit: { type: 'number' },
-            totalPages: { type: 'number' }
-        }
-    }
+      properties: {
+        items: {
+          type: 'array',
+          items: { $ref: getSchemaPath(Pets) },
+        },
+        total: { type: 'number' },
+        page: { type: 'number' },
+        limit: { type: 'number' },
+        totalPages: { type: 'number' },
+      },
+    },
   })
   @ApiBadRequestResponse({
     description: 'Parámetros de consulta inválidos',
@@ -76,10 +86,13 @@ export class PetsController {
   })
   @Public()
   @Get()
-  async getAllPets(@Query() findPetsDto: FindPetsDto): Promise<PaginatedResponse>{
+  async getAllPets(
+    @Query() findPetsDto: FindPetsDto,
+  ): Promise<PaginatedResponse> {
     return this.petsService.findAll(findPetsDto);
   }
 
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Obtener una mascota por su ID',
     description: 'Devuelve la mascota con el ID correspondiente.',
@@ -109,6 +122,7 @@ export class PetsController {
     return this.petsService.findById(id);
   }
 
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Crear una nueva mascota',
     description: 'Crea una nueva mascota en la plataforma.',
@@ -146,6 +160,7 @@ export class PetsController {
     return this.petsService.create(createPetDto);
   }
 
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Actualizar una mascota',
     description: 'Actualiza los datos de una mascota existente.',
@@ -194,6 +209,7 @@ export class PetsController {
     return this.petsService.update(id, updatePetDto);
   }
 
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'Eliminar una mascota',
     description: 'Elimina una mascota de la plataforma.',
@@ -238,5 +254,4 @@ export class PetsController {
   async deletePet(@Param('id') id: string): Promise<void> {
     return this.petsService.delete(id);
   }
-  
 }


### PR DESCRIPTION
# Cambios realizados:

- Se removió el decorador apiBearerAuth del controllador de Pets para asignarlo solo a los endpoints protegidos
- Se agregó un mensaje de error en español faltante en el campo name del registerUserDto
- Se removieron importaciones que no se estaban utilizando en el registerUserDto